### PR TITLE
Upgrade ```comment-json``` to 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@types/mocha": "^2.2.42"
     },
     "dependencies": {
-        "comment-json": "^1.1.3",
+        "comment-json": "^4.1.1",
         "tslint": "^5.8.0"
     }
 }


### PR DESCRIPTION
Recently vscode language configuration json for php has some tailing comma which is problematic when using tab on PHP files. [Check here](https://github.com/microsoft/vscode/blob/06a8e9bcd6534f910539a8d68dcde6cf396798d5/extensions/php/language-configuration.json#L61)
[Check here](https://github.com/microsoft/vscode/blob/06a8e9bcd6534f910539a8d68dcde6cf396798d5/extensions/php/language-configuration.json#L62)

I upgraded the comment-json package to the latest version to enable parsing tailing comma in vscode configuration json.