### PR TITLE
Fix a bug and package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "url": "https://github.com/garaemon/vscode-emacs-tab.git"
     },
     "engines": {
-        "vscode": "^1.18.0"
+        "vscode": "^1.67.0"
     },
     "categories": [
         "Other"

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
         "@types/node": "14.x",
         "@typescript-eslint/eslint-plugin": "^5.21.0",
         "@typescript-eslint/parser": "^5.21.0",
-        "@vscode/test-electron": "^2.1.3",
         "eslint": "^8.14.0",
         "glob": "^8.0.1",
         "mocha": "^9.2.2",
         "typescript": "^4.6.4"
+        "@vscode/test-electron": "^2.1.3",
     },
     "dependencies": {
         "comment-json": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -38,17 +38,17 @@
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "@types/vscode": "^1.67.0",
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.1",
         "@types/node": "14.x",
         "@typescript-eslint/eslint-plugin": "^5.21.0",
         "@typescript-eslint/parser": "^5.21.0",
+        "@vscode/test-electron": "^2.1.3",
         "eslint": "^8.14.0",
         "glob": "^8.0.1",
         "mocha": "^9.2.2",
         "typescript": "^4.6.4",
-        "@vscode/test-electron": "^2.1.3"
+        "vscode": "^1.1.37"
     },
     "dependencies": {
         "comment-json": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
         "eslint": "^8.14.0",
         "glob": "^8.0.1",
         "mocha": "^9.2.2",
-        "typescript": "^4.6.4"
-        "@vscode/test-electron": "^2.1.3",
+        "typescript": "^4.6.4",
+        "@vscode/test-electron": "^2.1.3"
     },
     "dependencies": {
         "comment-json": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
-        "test": "npm run compile && node ./node_modules/vscode/bin/test"
+        "test": "npm run compile && node ./out/test/index.js"
     },
     "devDependencies": {
+        "@types/vscode": "^1.67.0",
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.1",
         "@types/node": "14.x",
@@ -47,8 +48,7 @@
         "eslint": "^8.14.0",
         "glob": "^8.0.1",
         "mocha": "^9.2.2",
-        "typescript": "^4.6.4",
-        "vscode": "^1.1.37"
+        "typescript": "^4.6.4"
     },
     "dependencies": {
         "comment-json": "^4.1.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,11 +122,6 @@ class IndentationRule {
       return null;
     }
   }
-  {
-  "key": "tab",
-    "command": "tab",
-      "when": "editorTextFocus && !editorReadonly && !editorTabMovesFocus"
-}
   private createRegExp(s: string): RegExp {
   try {
     if (s && s.length > 0) {

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -10,13 +10,13 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-import * as testRunner from 'vscode/lib/testrunner';
+// import * as testRunner from 'vscode/lib/testrunner';
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
-testRunner.configure({
-    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
-    useColors: true // colored output from test results
-});
+// testRunner.configure({
+//     ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+//     useColors: true // colored output from test results
+// });
 
-module.exports = testRunner;
+// module.exports = testRunner;


### PR DESCRIPTION
Hi!

I tried to build the extension from source code and found some bugs.

When I run the commands : 
```sh
npm install 
vsce package
```
The following errors are occured : 
```
Executing prepublish script 'npm run vscode:prepublish'...

> vscode-emacs-tab@0.0.9 vscode:prepublish
> npm run compile


> vscode-emacs-tab@0.0.9 compile
> tsc -p ./

src/extension.ts:125:3 - error TS1068: Unexpected token. A constructor, method, accessor, or property was expected.                          

125   {
      ~

src/extension.ts:126:8 - error TS1005: ';' expected.

126   "key": "tab",
           ~

src/extension.ts:127:14 - error TS1005: ';' expected.

127     "command": "tab",
                 ~

src/extension.ts:128:13 - error TS1005: ';' expected.

128       "when": "editorTextFocus && !editorReadonly && !editorTabMovesFocus"
                ~

src/extension.ts:130:3 - error TS1128: Declaration or statement expected.

130   private createRegExp(s: string): RegExp {
      ~~~~~~~

src/extension.ts:130:25 - error TS1005: ',' expected.

130   private createRegExp(s: string): RegExp {
                            ~

src/extension.ts:130:34 - error TS1005: ';' expected.

130   private createRegExp(s: string): RegExp {
                                     ~

src/extension.ts:130:36 - error TS1434: Unexpected keyword or identifier.

130   private createRegExp(s: string): RegExp {
                                       ~~~~~~

src/extension.ts:141:1 - error TS1128: Declaration or statement expected.

141 }
    ~


Found 9 errors in the same file, starting at: src/extension.ts:125
****
```


```
Executing prepublish script 'npm run vscode:prepublish'...

> vscode-emacs-tab@0.0.9 vscode:prepublish
> npm run compile


> vscode-emacs-tab@0.0.9 compile
> tsc -p ./

src/test/index.ts:13:29 - error TS2307: Cannot find module 'vscode/lib/testrunner' or its corresponding type declarations.                   

13 import * as testRunner from 'vscode/lib/testrunner';
```

So, I fixed the followings.

- vscode dependency configs in package.json
- bugs in src/extension.ts
- test scripts (comment out out-dated scripts)

Sorry for multiple changes in a single PR, but this PR make the package to be more self-contained.