### PR TITLE
Hotfix for failure to find commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .vscode-test/
 .vsix
+*.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,7 +3,7 @@
 .gitignore
 .vscode-test/**
 .vscode/**
-node_modules/**
+# node_modules/**
 out/**/*.map
 out/test/**
 src/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-emacs-tab",
-    "version": "0.0.9",
+    "version": "0.0.17",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-emacs-tab",
     "displayName": "vscode-emacs-tab",
     "description": "emacs like tab behavior",
-    "version": "0.0.11",
+    "version": "0.0.17",
     "publisher": "garaemon",
     "repository": {
         "type": "git",
@@ -18,7 +18,7 @@
         "onCommand:emacs-tab.reindentCurrentLine",
         "onCommand:emacs-tab.debugEstimateIndentLevel"
     ],
-    "main": "./out/extension",
+    "main": "./out/extension.js",
     "contributes": {
         "commands": [
             {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,12 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "ES2020",
         "outDir": "out",
         "lib": [
-            "es6"
+            "ES2020"
         ],
         "sourceMap": true,
         "rootDir": "src"
-    },
-    "exclude": [
-        "node_modules",
-        ".vscode-test"
-    ]
+    }
 }


### PR DESCRIPTION
* Include node_modules in the extension.
* Bump up to 0.0.17
* Add .js suffix to endpoint.