### PR TITLE
Avoid error when language config is undefined

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -345,7 +345,7 @@ function getLanguageConfiguration(id: string): ILanguageConfiguration | null {
       ext.packageJSON.contributes.languages) {
       const packageLangData = ext.packageJSON.contributes.languages.find(
         (langData: any) => (langData.id === documentLanguageId));
-      if (packageLangData) {
+      if (packageLangData && packageLangData.configuration !== undefined) {
         const langConfigFilepath =
           path.join(ext.extensionPath, packageLangData.configuration);
         const configFileContent = fs.readFileSync(langConfigFilepath).toString();


### PR DESCRIPTION
This is a tiny fix so that the extension doesn't throw errors when running on a remote.  (This does not fix being unable to find the language configuration in such situations.)