### PR TITLE
Fix for yaml on some environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-emacs-tab",
     "displayName": "vscode-emacs-tab",
     "description": "emacs like tab behavior",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "garaemon",
     "repository": {
         "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -345,7 +345,9 @@ function getLanguageConfiguration(id: string): ILanguageConfiguration | null {
       ext.packageJSON.contributes.languages) {
       const packageLangData = ext.packageJSON.contributes.languages.find(
         (langData: any) => (langData.id === documentLanguageId));
-      if (packageLangData) {
+      // packageLangData.configuration can be undefined. For example, configuration of the ROS
+      // extension is undefined.
+      if (packageLangData && packageLangData.configuration) {
         const langConfigFilepath =
           path.join(ext.extensionPath, packageLangData.configuration);
         const configFileContent = fs.readFileSync(langConfigFilepath).toString();


### PR DESCRIPTION
* If ROS extension is installed, yaml files cannot be indented.
* This is because packageLangData.configuration of ROS extension is
  undefined.